### PR TITLE
docs: add pedagagical section on example incentives

### DIFF
--- a/docs/design-document.md
+++ b/docs/design-document.md
@@ -110,6 +110,15 @@ Polygon is chosen for its scalability, low transaction costs, and security.
 It is also a good choice as other BBs (Identity, Wallet) have built on Polygon.
 Information stored on the blockchain includes transaction records, token balances, and some metadata.
 
+### Example Incentives
+
+To better understand how points can be distributed in the ecosystem, let's take a look at example incentives that could be used
+* As a use case leader, I can provide X points to the Data Provider when they join my use case
+* As a use case leader, I can provide X points to a Data Provider after a successful transaction
+* As a Data Provider, I can provide X points to a Service Provider after a successful response from their service
+
+> These are only a sample of all the incentives that could be used for token distribution with the DVCT
+
 ## Integrations
 
 In order to make the BB function, the integration with other BB is expected:


### PR DESCRIPTION
Adds a section providing with some examples of incentives that could be used with the component.

This is done with a pedagogical approach in mind for implementors to understand the context in which it could be used.